### PR TITLE
Update of snap for snapcraft-rust-example tag v0.0.5

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -28,12 +28,6 @@ jobs:
       - name: "Checkout"
         uses: actions/checkout@v3
 
-      - name: "debug location"
-        run: |
-          pwd
-          ls -al
-          ls -al template
-
       - name: "Create the snap from the template"
         run: |
           cp template/snapcraft.yaml snapcraft.yaml

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -24,8 +24,7 @@ parts:
   rust-example:
     plugin: rust
     source: https://github.com/a1ecbr0wn/snapcraft/archive/refs/tags/v0.0.5.tar.gz
-    rust-path: ["snapcraft-rust-example"]
 
 apps:
   rust-example:
-    command: bin/snapcraft-rust-example
+    command: bin/rust-example

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -24,7 +24,8 @@ parts:
   rust-example:
     plugin: rust
     source: https://github.com/a1ecbr0wn/snapcraft/archive/refs/tags/v0.0.5.tar.gz
+    rust-path: ["snapcraft-rust-example"]
 
 apps:
   rust-example:
-    command: bin/rust-example
+    command: bin/snapcraft-rust-example


### PR DESCRIPTION
Update snap for v0.0.5
- Change to version number
- Change of source file link
- Auto-generated by workflow