### PR TITLE
fix: cargo.toml broken repo and doc links

### DIFF
--- a/snapcraft-rust-example/Cargo.toml
+++ b/snapcraft-rust-example/Cargo.toml
@@ -6,13 +6,11 @@ authors = ["Alec Brown <alec@noser.net>"]
 description = "Test application for snapcraft rust library."
 rust-version = "1.58"
 license = "Apache-2.0"
-repository = "https://github.com/a1ecbr0wn/snapcraft/snapcraft-rust-example"
-homepage = "https://github.com/a1ecbr0wn/snapcraft/snapcraft-rust-example"
+repository = "https://github.com/a1ecbr0wn/snapcraft/tree/main/snapcraft-rust-example"
+homepage = "https://github.com/a1ecbr0wn/snapcraft/tree/main/snapcraft-rust-example"
 readme = "README.md"
 keywords = ["shell", "filesystem", "utility"]
 categories = ["filesystem", "os", "api-bindings"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bin]]
 path = "src/main.rs"

--- a/snapcraft/Cargo.toml
+++ b/snapcraft/Cargo.toml
@@ -6,14 +6,12 @@ authors = ["Alec Brown <alec@noser.net>"]
 description = "Access to snapcraft environment."
 rust-version = "1.58"
 license = "Apache-2.0"
-repository = "https://github.com/a1ecbr0wn/snapcraft/snapcraft"
-homepage = "https://github.com/a1ecbr0wn/snapcraft/snapcraft"
+repository = "https://github.com/a1ecbr0wn/snapcraft/tree/main/snapcraft"
+homepage = "https://github.com/a1ecbr0wn/snapcraft/tree/main/snapcraft"
 documentation = "https://docs.rs/snapcraft"
 readme = "README.md"
 keywords = ["shell", "filesystem", "utility"]
 categories = ["filesystem", "os", "api-bindings"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 


### PR DESCRIPTION
I was looking through this project and I saw that the repo and doc links on crates.io are broken.

This PR fixes them by linking to the tree/main path but its worth to note that on popular projects with multiple crates (like [actix-web](https://github.com/actix/actix-web)), they link each of their crates to the main repo (not to the crate's path on that repo), I would advocate to do the same as the example crate is not published, should I change it?

Note: also removes the default "See more keys" comment.